### PR TITLE
Add exclude field to cargo package section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2021"
 readme = "./README.md"
 license = "MIT"
 repository = "https://github.com/onecodex/mmap-bitvec"
-
+exclude = [
+    ".github/",
+    ".gitignore"
+]
 
 [dependencies]
 memmap2 = "0.5"


### PR DESCRIPTION
I'm pretty sure we don't need / want to include our `.github` or `.gitignore` files in what gets sent to crates.io