### PR TITLE
Fix for Rust 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-22.04
-          rust: 1.60.0
+          rust: 1.69.0
         - build: stable
           os: ubuntu-22.04
           rust: stable

--- a/src/mmap_bitvec.rs
+++ b/src/mmap_bitvec.rs
@@ -513,7 +513,7 @@ impl BitVector for MmapBitVec {
                 // we have to transmute since we don't know if it's a u64 or u128
                 #[allow(clippy::transmute_ptr_to_ptr)]
                 let lg_ptr: *const u128 = transmute(ptr.add(byte_idx_st));
-                v |= (*lg_ptr).to_be() << (r.start & 7) >> (128 - new_size);
+                v |= lg_ptr.read_unaligned().to_be() << (r.start & 7) >> (128 - new_size);
             }
         } else {
             // special case if we can't get a whole u64 out without running outside the buffer
@@ -526,7 +526,7 @@ impl BitVector for MmapBitVec {
         }
 
         // mask out the high bits in case we copied extra
-        v & (u128::max_value() >> (128 - new_size))
+        v & (u128::MAX >> (128 - new_size))
     }
 
     /// Set an unaligned range of bits using a `u64`.

--- a/src/mmap_bitvec.rs
+++ b/src/mmap_bitvec.rs
@@ -701,7 +701,7 @@ mod test {
 
     #[test]
     fn test_bitvec_get_range() {
-        let mut b = MmapBitVec::from_memory(128).unwrap();
+        let mut b = MmapBitVec::from_memory(1024).unwrap();
         b.set(2, true);
         b.set(3, true);
         b.set(5, true);

--- a/src/mmap_bitvec.rs
+++ b/src/mmap_bitvec.rs
@@ -192,7 +192,7 @@ impl MmapBitVec {
                 io::ErrorKind::InvalidData,
                 format!(
                     "file should be {} bytes (with {} header), but file is {} bytes",
-                    byte_size + total_header_size as u64,
+                    byte_size + total_header_size,
                     total_header_size,
                     file.metadata()?.len(),
                 ),
@@ -282,9 +282,9 @@ impl MmapBitVec {
         if r.end > self.size {
             panic!("Range ends outside of BitVec")
         }
-        let byte_idx_st = (r.start >> 3) as usize;
-        let byte_idx_en = ((r.end - 1) >> 3) as usize;
-        let new_size: usize = (((r.end - r.start) as usize - 1) >> 3) + 1;
+        let byte_idx_st = r.start >> 3;
+        let byte_idx_en = (r.end - 1) >> 3;
+        let new_size: usize = (((r.end - r.start) - 1) >> 3) + 1;
 
         let ptr: *const u8 = self.mmap.as_ptr();
         let mut v = vec![0; new_size];
@@ -333,7 +333,7 @@ impl MmapBitVec {
         } else {
             0
         };
-        let byte_idx_en = ((r.end - 1) >> 3) as usize;
+        let byte_idx_en = (r.end - 1) >> 3;
 
         let mmap: *mut u8 = self
             .mmap
@@ -406,8 +406,8 @@ impl BitVector for MmapBitVec {
 
     /// Return the number of set bits in the range `r`
     fn rank(&self, r: Range<usize>) -> usize {
-        let byte_idx_st = (r.start >> 3) as usize;
-        let byte_idx_en = ((r.end - 1) >> 3) as usize;
+        let byte_idx_st = r.start >> 3;
+        let byte_idx_en = (r.end - 1) >> 3;
         let mmap: *const u8 = self.mmap.as_ptr();
 
         let mut bit_count = 0usize;
@@ -452,7 +452,7 @@ impl BitVector for MmapBitVec {
 
     /// Return the position of the `nth` set bit with `start` treated as the 0th position, or `None` if there is no set bit
     fn select(&self, n: usize, start: usize) -> Option<usize> {
-        let byte_idx_st = (start >> 3) as usize;
+        let byte_idx_st = start >> 3;
         let size_front = 8u8 - (start & 7) as u8;
         let mmap: *const u8 = self.mmap.as_ptr();
 
@@ -494,8 +494,8 @@ impl BitVector for MmapBitVec {
         } else if r.end > self.size {
             panic!("Range ends outside of BitVec")
         }
-        let byte_idx_st = (r.start >> 3) as usize;
-        let byte_idx_en = ((r.end - 1) >> 3) as usize;
+        let byte_idx_st = r.start >> 3;
+        let byte_idx_en = (r.end - 1) >> 3;
         let new_size: u8 = (r.end - r.start) as u8;
 
         let mut v;
@@ -542,8 +542,8 @@ impl BitVector for MmapBitVec {
         if r.end > self.size {
             panic!("Range ends outside of BitVec")
         }
-        let byte_idx_st = (r.start >> 3) as usize;
-        let byte_idx_en = ((r.end - 1) >> 3) as usize;
+        let byte_idx_st = r.start >> 3;
+        let byte_idx_en = (r.end - 1) >> 3;
         let new_size: u8 = (r.end - r.start) as u8;
 
         // split off the front byte
@@ -602,8 +602,8 @@ impl BitVector for MmapBitVec {
         if (r.end - 1) > self.size {
             panic!("Range ends outside of BitVec")
         }
-        let byte_idx_st = (r.start >> 3) as usize;
-        let byte_idx_en = ((r.end - 1) >> 3) as usize;
+        let byte_idx_st = r.start >> 3;
+        let byte_idx_en = (r.end - 1) >> 3;
 
         let mmap: *mut u8 = self
             .mmap


### PR DESCRIPTION
rust-bfield started failing with 1.70 because of https://github.com/rust-lang/rust/pull/98112

We do not have a failing test for it in this repo though, it was only happening through rust-bfield